### PR TITLE
docs: fix NodePort→ingress, kind→k3d, site metadata (1.3.0 audit)

### DIFF
--- a/docs/3-codespaces.md
+++ b/docs/3-codespaces.md
@@ -21,7 +21,7 @@ Click to open Codespaces for this lab repository:
 
 ### Wait for Codespace
 
-We know your time is very valuable. This codespace takes around 7-10 minutes to be fully operational. A local Kubernetes ([kind](https://kind.sigs.k8s.io/){target="_blank"}) cluster will be configured and in it a sample application, Astronomy Shop, will be deployed. To make your experience better, we are also installing and configuring tools like:
+We know your time is very valuable. This codespace takes around 7-10 minutes to be fully operational. A local Kubernetes ([k3d](https://k3d.io/){target="_blank"}) cluster will be configured and in it a sample application, Astronomy Shop, will be deployed. To make your experience better, we are also installing and configuring tools like:
 
 **k9s kubectl helm node jq python3 gh**
 
@@ -29,7 +29,7 @@ We know your time is very valuable. This codespace takes around 7-10 minutes to 
 
 Your Codespace has now deployed the following resources:
 
-- A local Kubernetes ([kind](https://kind.sigs.k8s.io/){target="_blank"}) cluster, with some pre-deployed apps that will be used later in the demo.
+- A local Kubernetes ([k3d](https://k3d.io/){target="_blank"}) cluster, with some pre-deployed apps that will be used later in the demo.
 
 After a couple of minutes, you'll see this screen in your Codespaces terminal. It contains the links to the UI of the application which we will be using for our hands-on training.
 
@@ -89,7 +89,7 @@ kubectl get events -n default
 ```
 
 ### App exposure
-The astronomy-shop application is exposed via NodePort and it's mapping port 8080 to Cluster port 30100.
+The astronomy-shop application is accessible via the nginx ingress controller. The URL is shown in the greeting — run `printGreeting` to display it.
 
 Verify service:
 ```sh


### PR DESCRIPTION
## Summary

- Replace NodePort port exposure references with nginx ingress / `printGreeting` pattern
- Update Kubernetes cluster description from `kind` to `k3d`
- Fix `site_name` and `repo_url` in `mkdocs.yaml` (copy-paste from template, never updated)
- Remove `scratch.md` debug file (live-debugger only)
- Fix stale `codespaces-synchronizer` reference → `codespaces-framework` (bizobs only)

Part of the post-1.3.0 documentation audit.

## Test plan
- [ ] Verify MkDocs site builds and renders correct `site_name` in browser title
- [ ] Verify "View Code on GitHub" link points to the correct repo
- [ ] Verify app URLs reference `printGreeting` instead of hardcoded ports