### PR TITLE
fix(ci): resolve postCreateCommand failure on main

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,7 +5,7 @@ source .devcontainer/util/source_framework.sh
 
 setUpTerminal
 
-startKindCluster
+startCluster
 
 installK9s
 

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -9,6 +9,6 @@ source .devcontainer/util/source_framework.sh
 setBaseDir
 
 # attach to kind cluster
-startKindCluster
+startCluster
 
 printInfoSection "Your dev.container finished starting up"


### PR DESCRIPTION
Automated fix by the Enablement Ops agent.

## Root cause

`post-create.sh` and `post-start.sh` called `startKindCluster` directly, forcing the Kind engine in every environment. On Orbital (Sysbox) the framework explicitly documents that Kind cannot run — the 4-level container nesting (Sysbox → DinD → dt-enablement → kind-node → pod containers) leaves pod sandboxes stuck in `ContainerCreating` indefinitely. The failing CI log shows exactly that signature: `coredns`, `local-path-provisioner`, `ingress-nginx`, and every `astronomy-shop-*` pod stuck in `ContainerCreating` / `Init:0/1` after 10+ minutes, hitting the 60-retry wait timeout in `waitForAllReadyPods astronomy-shop`.

## Fix

Switch both lifecycle scripts to the framework's unified `startCluster`, which routes to k3d by default (works on Orbital) and still honors `CLUSTER_ENGINE=kind` for Codespaces/local users who want Kind explicitly.