### PR TITLE
refactor: expose Astronomy Shop via ingress instead of NodePort 30100

### DIFF
--- a/.devcontainer/util/my_functions.sh
+++ b/.devcontainer/util/my_functions.sh
@@ -40,15 +40,8 @@ deployAstronomyShopOpenTelemetry() {
   # Wait for ready pods
   waitForAllReadyPods astronomy-shop
 
-  printInfoSection "Exposing Astronomy Shop via NodePort 30100"
-
-  printInfo "Change astroshop-frontendproxy service from LoadBalancer to NodePort"
-  kubectl patch service astronomy-shop-frontendproxy --namespace=astronomy-shop  --patch='{"spec": {"type": "NodePort"}}'
-
-  printInfo "Define the NodePort to expose the app from the Cluster"
-  kubectl patch service astronomy-shop-frontendproxy --namespace=astronomy-shop --type='json' --patch='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":30100}]'
-
-  waitAppCanHandleRequests 30100
+  # Expose via nginx ingress (replaces legacy NodePort 30100)
+  exposeAstronomyShop
 
   printInfo "Astroshop deployed succesfully"
 
@@ -56,15 +49,11 @@ deployAstronomyShopOpenTelemetry() {
 
 exposeAstronomyShop() {
 
-  printInfoSection "Exposing Astronomy Shop via NodePort 30100"
+  printInfoSection "Exposing Astronomy Shop via nginx ingress"
 
-  printInfo "Change astroshop-frontendproxy service from LoadBalancer to NodePort"
-  kubectl patch service astronomy-shop-frontendproxy --namespace=astronomy-shop  --patch='{"spec": {"type": "NodePort"}}'
-
-  printInfo "Define the NodePort to expose the app from the Cluster"
-  kubectl patch service astronomy-shop-frontendproxy --namespace=astronomy-shop --type='json' --patch='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":30100}]'
-
-  waitAppCanHandleRequests 30100
+  # frontendproxy listens on 8080; registerApp creates the Ingress + registry
+  # entry and prints the reachable URL (sslip.io / Codespaces / Orbital).
+  registerApp "astronomy-shop" "astronomy-shop" "astronomy-shop-frontendproxy" 8080
 
   printInfo "AstronomyShop exposed succesfully"
 


### PR DESCRIPTION
## Summary
The framework removed the legacy NodePort path (codespaces-framework#55). This repo's `my_functions.sh` still patched `astronomy-shop-frontendproxy` to NodePort 30100 and waited on `localhost:30100` — broken once the framework no longer maps that port.

## Change
- `exposeAstronomyShop` now calls `registerApp "astronomy-shop" "astronomy-shop" "astronomy-shop-frontendproxy" 8080` (nginx ingress)
- `deployAstronomyShopOpenTelemetry` delegates to `exposeAstronomyShop` (removes duplicated NodePort block)

## Verification
Sourced the framework functions with a mocked `kubectl`; `exposeAstronomyShop` produces the correct 3-rule Ingress (sslip.io + hostname + catch-all) → `frontendproxy:8080` and writes the 7-field registry entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)