### PR TITLE
fix: start k3d in post-start to match post-create

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -8,7 +8,7 @@ source .devcontainer/util/source_framework.sh
 
 setBaseDir
 
-# attach to kind cluster
-startKindCluster
+# attach to cluster (k3d — matches post-create; Orbital standard)
+startK3dCluster
 
 printInfoSection "Your dev.container finished starting up"


### PR DESCRIPTION
## Problem
`post-create.sh` provisions **k3d**, but `post-start.sh` still called `startKindCluster`. On a container restart this attempted to start kind over the existing k3d cluster — inconsistent and broken on Orbital/Sysbox.

## Fix
Align `post-start.sh` to `startK3dCluster` (Orbital standard, consistent with post-create).

🤖 Generated with [Claude Code](https://claude.com/claude-code)